### PR TITLE
Kp cat create delete

### DIFF
--- a/src/components/cards/CatCard.js
+++ b/src/components/cards/CatCard.js
@@ -45,11 +45,10 @@ export default function CatCard(props) {
           </Typography>
         </CardContent>
         <CardActions>
-          {/* TODO: Change from href, it's forcing a refresh */}
           <Button 
             variant="contained" 
             color="primary" 
-            href={`cats/${cat.id}`}
+            onClick={() => props.history.push(`cats/${cat.id}`)}
           >
             Details
           </Button>

--- a/src/components/forms/CatForm.js
+++ b/src/components/forms/CatForm.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+
+const CatForm = props => {
+  const [adoptionStatusList, setAdoptionStatusList] = useState();
+
+  let isEdit = false
+  if (Object.keys(props.formData).length !== 0) {
+    isEdit = true
+  }
+  const classes = props.classes;
+  const handleFieldChange = props.handleFieldChange;
+  const handleSubmit = props.handleSubmit;
+
+  // const getAdoptionStatusList = () => {
+
+  // }
+
+  useEffect( () => {
+    // setUserToEdit()
+  }, [])
+
+  return (
+    <>
+      <div>
+        <form 
+          className={classes.form} 
+          onSubmit={handleSubmit}
+          autoComplete="on"
+        >
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                name="name"
+                variant="outlined"
+                required
+                fullWidth
+                id="name"
+                label="Name"
+                autoFocus
+                onChange={handleFieldChange}
+                value={isEdit ? props.formData.name : null}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              {/* CREATOR ID */}
+              {/* <SELECT/> */}
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                id="date"
+                label="Birthday"
+                type="date"
+                className={classes.textField}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Grid>
+            {/* TODO: Stretch Goal: Breed */}
+            {/* TODO: Adoption Status */}
+            {/* TODO: If Adopted, 
+                Adopted Date,
+                Adopted Id 
+            */}
+            {/* TODO: Optional: Bonded Pair Cat */}
+            {/* TODO: Optional: Litter */}
+            <Grid item xs={12} sm={6}>
+              <TextField
+                id="fixed_date"
+                label="fixed_date"
+                type="date"
+                className={classes.textField}
+                onChange={handleFieldChange}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Grid>
+            {/* TODO: Optional: Image Upload */}
+
+          </Grid>
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            color="primary"
+            className={classes.submit}
+          >
+            Submit
+          </Button>
+        </form>
+      </div>
+    </>
+  ) 
+}
+
+export default CatForm

--- a/src/components/forms/CatForm.js
+++ b/src/components/forms/CatForm.js
@@ -10,13 +10,15 @@ import { catManager } from "../../modules";
 const CatForm = props => {
   const [adoptionStatusList, setAdoptionStatusList] = useState([]);
 
-  let isEdit = false
-  if (Object.keys(props.formData).length !== 0) {
-    isEdit = true
-  }
   const classes = props.classes;
   const handleFieldChange = props.handleFieldChange;
   const handleSubmit = props.handleSubmit;
+  const formState = props.formState;
+
+  let isEdit = false
+  if (Object.keys(props.formState).length !== 0) {
+    isEdit = true
+  }
 
   const getAdoptionStatusList = () => {
     catManager.getAdoptionStatusList()
@@ -46,15 +48,32 @@ const CatForm = props => {
                 label="Name"
                 autoFocus
                 onChange={handleFieldChange}
-                value={isEdit ? props.formData.name : null}
+                value={isEdit ? props.formState.name : null}
               />
             </Grid>
+
+            {/* TODO: CREATOR ID, once auth is built */}
+
             <Grid item xs={12} sm={6}>
-            {/* CREATOR ID */}
-            {/* <SELECT/> */}
-            {/* TODO: SELECT SEX */}
+              <InputLabel id="sex">Sex</InputLabel>
+                <Select
+                  inputProps={{
+                    required: true,
+                  }}
+                  required
+                  name="sex"
+                  fullWidth
+                  labelId="sex"
+                  id="sex"
+                  onChange={handleFieldChange}
+                >
+                  <MenuItem value="">Select</MenuItem>
+                  <MenuItem key="Male" value="Male">Male</MenuItem>
+                  <MenuItem key="Female" value="Female">Female</MenuItem>
+                </Select>
             </Grid>
-            <Grid item xs={12}>
+            
+            <Grid item xs={12} sm={6}>
               <TextField
                 id="birth_date"
                 name="birth_date"
@@ -67,7 +86,22 @@ const CatForm = props => {
                 }}
               />
             </Grid>
+
             {/* TODO: Stretch Goal: Breed */}
+            <Grid item xs={12} sm={6}>
+              <TextField
+                id="fixed_date"
+                label="fixed_date"
+                type="date"
+                className={classes.textField}
+                onChange={handleFieldChange}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={4}>  
             <InputLabel id="adoption_status">Adoption Status</InputLabel>
               <Select
                 inputProps={{
@@ -87,26 +121,31 @@ const CatForm = props => {
                   </MenuItem>
                 ))}
               </Select>
+            </Grid>
+            
+            {/* Adopted Status 4 is "Adopted", so then we ask for the date and the adopter */}
+            {formState.adoption_status === 4
+              ? <>
+                  {/* TODO: If Adopted, Adopted Id */}
+                  <Grid item xs={12} sm={4}>
+                    <TextField
+                      id="adopted_date"
+                      label="adopted_date"
+                      type="date"
+                      className={classes.textField}
+                      onChange={handleFieldChange}
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                    />
+                  </Grid>
+                </>
+              : <>
+                </>
+            }
 
-
-            {/* TODO: If Adopted, 
-                Adopted Date,
-                Adopted Id 
-            */}
             {/* TODO: Optional: Bonded Pair Cat */}
             {/* TODO: Optional: Litter */}
-            <Grid item xs={12} sm={6}>
-              <TextField
-                id="fixed_date"
-                label="fixed_date"
-                type="date"
-                className={classes.textField}
-                onChange={handleFieldChange}
-                InputLabelProps={{
-                  shrink: true,
-                }}
-              />
-            </Grid>
             {/* TODO: Optional: Image Upload */}
 
           </Grid>

--- a/src/components/forms/CatForm.js
+++ b/src/components/forms/CatForm.js
@@ -2,9 +2,13 @@ import React, { useState, useEffect } from "react";
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import InputLabel from "@material-ui/core/InputLabel";
+import { catManager } from "../../modules";
 
 const CatForm = props => {
-  const [adoptionStatusList, setAdoptionStatusList] = useState();
+  const [adoptionStatusList, setAdoptionStatusList] = useState([]);
 
   let isEdit = false
   if (Object.keys(props.formData).length !== 0) {
@@ -14,12 +18,13 @@ const CatForm = props => {
   const handleFieldChange = props.handleFieldChange;
   const handleSubmit = props.handleSubmit;
 
-  // const getAdoptionStatusList = () => {
-
-  // }
+  const getAdoptionStatusList = () => {
+    catManager.getAdoptionStatusList()
+      .then(setAdoptionStatusList)
+  }
 
   useEffect( () => {
-    // setUserToEdit()
+    getAdoptionStatusList()
   }, [])
 
   return (
@@ -45,22 +50,45 @@ const CatForm = props => {
               />
             </Grid>
             <Grid item xs={12} sm={6}>
-              {/* CREATOR ID */}
-              {/* <SELECT/> */}
+            {/* CREATOR ID */}
+            {/* <SELECT/> */}
+            {/* TODO: SELECT SEX */}
             </Grid>
             <Grid item xs={12}>
               <TextField
-                id="date"
+                id="birth_date"
+                name="birth_date"
                 label="Birthday"
                 type="date"
                 className={classes.textField}
+                onChange={handleFieldChange}
                 InputLabelProps={{
                   shrink: true,
                 }}
               />
             </Grid>
             {/* TODO: Stretch Goal: Breed */}
-            {/* TODO: Adoption Status */}
+            <InputLabel id="adoption_status">Adoption Status</InputLabel>
+              <Select
+                inputProps={{
+                  required: true,
+                }}
+                required
+                name="adoption_status"
+                fullWidth
+                labelId="adoptionStatus"
+                id="adoption_status"
+                onChange={handleFieldChange}
+              >
+                <MenuItem value="">Select</MenuItem>
+                {adoptionStatusList.map((status, i) => (
+                  <MenuItem key={i} value={status.id}>
+                    {status.name}
+                  </MenuItem>
+                ))}
+              </Select>
+
+
             {/* TODO: If Adopted, 
                 Adopted Date,
                 Adopted Id 

--- a/src/components/forms/index.js
+++ b/src/components/forms/index.js
@@ -1,0 +1,1 @@
+export { default as CatForm } from "./CatForm"

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
 export { CatCard } from "./cards"
 export { NavBar } from "./navbar"
+export { CatForm } from "./forms"

--- a/src/modules/api/catManager.js
+++ b/src/modules/api/catManager.js
@@ -8,5 +8,15 @@ export default {
   getCat(id) {
     return fetch(`${baseurl}/cats/${id}`)
       .then((resp) => resp.json())
+  },
+  // TODO: Add authentication
+  delete(id) {
+    return fetch(`${baseurl}/cats/${id}`, {
+      method: "DELETE",
+      headers: {
+        "content-type": "application/json",
+        // "Authorization": `Token ${token}`
+      }
+    })
   }
 }

--- a/src/modules/api/catManager.js
+++ b/src/modules/api/catManager.js
@@ -18,5 +18,30 @@ export default {
         // "Authorization": `Token ${token}`
       }
     })
+  },
+  getAdoptionStatusList() {
+    return fetch(`${baseurl}/adoptionstatus`)
+      .then((resp) => resp.json())
+  },
+  post(obj){
+    // Note: Content-type cannot be set when uploading a file
+    
+    // TODO: uncomment once auth is implemented
+    const headers = {
+      // Authorization: `Token ${token}`,
+    }
+
+    // If there is no image, 
+    // then content-type and accept are needed in the fetch call
+    if (obj.image_path === null) { 
+      headers["Accept"] = "application/json";
+      headers["Content-Type"] = "application/json";
+    } 
+
+    return fetch(`${baseurl}/cats`, {
+      method: "POST",
+      headers: headers,
+      body: obj
+    }).then((resp) => resp.json())
   }
 }

--- a/src/modules/formHandler.js
+++ b/src/modules/formHandler.js
@@ -1,0 +1,20 @@
+
+export default {
+  gatherFormData(formState) {
+    const formdata = new FormData();
+    for(const key in formState) {
+      formdata.append(key, formState[key])
+    };
+    return formdata
+  },
+  handleFieldChange(evt, formState, setFunction) {
+    const stateToChange = { ...formState };
+    if (evt.target.id) {
+      stateToChange[evt.target.id] = evt.target.value;
+    // Some Material UI components (select) have names, not ids:
+    } else if (evt.target.name) {
+      stateToChange[evt.target.name] = evt.target.value;
+    }
+    setFunction(stateToChange);
+  }
+}

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,2 +1,3 @@
 export { catManager } from "./api";
 export { default as momentManager } from "./momentManager";
+export { default as formHandler } from "./formHandler";

--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -6,7 +6,7 @@ import {
   // Redirect,
   // useHistory,
 } from "react-router-dom";
-import { Cats, CatDetails } from "./cats" 
+import { Cats, CatDetails, CatCreate } from "./cats" 
 import { NavBar } from "../components"
 import { Container } from '@material-ui/core';
 
@@ -18,8 +18,9 @@ const Routes = props => {
 
       <Container maxWidth="md">
 
-        {/* Cat List */}
         <Switch>
+
+          {/* Cat List */}
           <Route
             exact
             path="/cats"
@@ -27,10 +28,8 @@ const Routes = props => {
               <Cats {...props} />
             }
           />
-        </Switch>
 
-        {/* Cat Details */}
-        <Switch>
+          {/* Cat Details */}
           <Route
             exact
             path="/cats/:catId(\d+)"
@@ -41,6 +40,16 @@ const Routes = props => {
               />
             )}
           />
+
+          {/* Cat Creation Form */}
+          <Route
+            exact
+            path="/cats/new"
+            render={(props) =>
+              <CatCreate {...props}/>
+            }
+          />
+
         </Switch>
 
       </Container>

--- a/src/pages/cats/CatCreate.js
+++ b/src/pages/cats/CatCreate.js
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from "react"
+import { makeStyles } from '@material-ui/core/styles';
+import { CatForm } from "../../components"
+import { catManager } from "../../modules";
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginTop: theme.spacing(8),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(3),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+}));
+
+const CatCreate = props => {
+  const [formData, setFormData] = useState({})
+
+  const handleFieldChange = evt => {
+    const stateToChange = { ...formData };
+    stateToChange[evt.target.id] = evt.target.value;
+    setFormData(stateToChange);
+  };
+
+  const gatherFormData = () => {
+    const formdata = new FormData(formData);
+    return formdata
+  }
+
+  const handleSubmit = evt => {
+    evt.preventDefault();
+    // const token = window.sessionStorage.getItem("token");
+
+    const formdata = gatherFormData()
+    // const token = sessionStorage.getItem("token")
+    catManager.post(formdata)
+      .then((resp) => {
+        props.history.push({
+          pathname: `/cats/${resp.id}`
+        })
+      })
+  };
+
+  return (
+    <>
+      <h1>Cat Registration Form</h1>
+      <CatForm 
+        classes={useStyles()}
+        handleFieldChange={handleFieldChange}
+        handleSubmit={handleSubmit}
+        formData={formData}
+      />
+    </>
+  )
+}
+
+export default CatCreate

--- a/src/pages/cats/CatCreate.js
+++ b/src/pages/cats/CatCreate.js
@@ -50,7 +50,7 @@ const CatCreate = props => {
         classes={useStyles()}
         handleFieldChange={handleFieldChange}
         handleSubmit={handleSubmit}
-        formData={formState}
+        formState={formState}
       />
     </>
   )

--- a/src/pages/cats/CatCreate.js
+++ b/src/pages/cats/CatCreate.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { makeStyles } from '@material-ui/core/styles';
 import { CatForm } from "../../components"
-import { catManager } from "../../modules";
+import { catManager, formHandler } from "../../modules";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -24,24 +24,16 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const CatCreate = props => {
-  const [formData, setFormData] = useState({})
-
-  const handleFieldChange = evt => {
-    const stateToChange = { ...formData };
-    stateToChange[evt.target.id] = evt.target.value;
-    setFormData(stateToChange);
-  };
-
-  const gatherFormData = () => {
-    const formdata = new FormData(formData);
-    return formdata
-  }
+  const [formState, setFormState] = useState(
+    // FIXME: once auth is implemented
+    {"creator_id": 1}
+  )
+  const handleFieldChange = (evt) => formHandler.handleFieldChange(evt, formState, setFormState);
 
   const handleSubmit = evt => {
     evt.preventDefault();
     // const token = window.sessionStorage.getItem("token");
-
-    const formdata = gatherFormData()
+    const formdata = formHandler.gatherFormData(formState)
     // const token = sessionStorage.getItem("token")
     catManager.post(formdata)
       .then((resp) => {
@@ -58,7 +50,7 @@ const CatCreate = props => {
         classes={useStyles()}
         handleFieldChange={handleFieldChange}
         handleSubmit={handleSubmit}
-        formData={formData}
+        formData={formState}
       />
     </>
   )

--- a/src/pages/cats/CatDetails.js
+++ b/src/pages/cats/CatDetails.js
@@ -113,13 +113,3 @@ export default function CatDetails (props) {
     </>
   )
 }
-
-/*
-
-  'id', 'creator_id', "birth_date", "name",
-                "litter_id", "bonded_pair_cat_id", "sex",
-                "fixed_date", "created_date", "modified_date",
-                "adoption_status_id", "image_path", "breed",
-                "adopted_date", "adopted_id"
-
-*/

--- a/src/pages/cats/CatDetails.js
+++ b/src/pages/cats/CatDetails.js
@@ -4,6 +4,7 @@ import { Typography } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import { catManager, momentManager } from "../../modules";
+import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -22,6 +23,11 @@ export default function CatDetails (props) {
   const getCat = () => {
     catManager.getCat(props.catId)
       .then(setCat)
+  }
+
+  const handleDelete = () => {
+    catManager.delete(props.catId)
+      .then(props.history.push('/cats'))
   }
 
   useEffect(() => {
@@ -97,6 +103,13 @@ export default function CatDetails (props) {
           Last Modified: {momentManager.getMomentFromNow(cat.modified_date)}
         </Grid>
       </Grid>
+      <Button 
+        variant="contained" 
+        color="primary" 
+        onClick={handleDelete}
+      >
+        Delete
+      </Button>
     </>
   )
 }

--- a/src/pages/cats/Cats.js
+++ b/src/pages/cats/Cats.js
@@ -25,6 +25,7 @@ const Cats = props => {
           <CatCard
             key={cat.id}
             cat={cat}
+            {...props}
           />
         ))}
       </Box>

--- a/src/pages/cats/index.js
+++ b/src/pages/cats/index.js
@@ -1,2 +1,3 @@
 export { default as Cats } from "./Cats"
 export { default as CatDetails } from "./CatDetails"
+export { default as CatCreate } from "./CatCreate"


### PR DESCRIPTION
Functionality Added:
- users can now delete cats (per #3, though without auth integration yet)
- users can now create new cats using the cat form (completing #16)

List of changes:
- added delete method to catmanager, delete button to catdetails 
- created catcreate page and form, updated routes and indexes accordingly
- created formHandler module to store universal form associated methods
- added post method to catManager
- changed catcard details button from href to onclick to keep from hard refreshing