### PR TITLE
restricting edit/delete

### DIFF
--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -16,8 +16,9 @@ const Routes = props => {
   const isAuthenticated = () => sessionStorage.getItem("token") !== null;
   const [hasUser, setHasUser] = useState(isAuthenticated());
 
-  const setUserToken = (resp) => {
-    sessionStorage.setItem("token", resp.token);
+  const setAuth = (resp) => {
+    sessionStorage.setItem("user_id", resp.user_id)
+    sessionStorage.setItem("token", resp.token)
     setHasUser(isAuthenticated());
   };
 
@@ -135,7 +136,7 @@ const Routes = props => {
               ? (<Redirect to="/" />) 
               : (
                   <Register
-                    setUserToken={setUserToken}
+                    setAuth={setAuth}
                     {...props}
                   />
                 )
@@ -150,7 +151,7 @@ const Routes = props => {
               ? (<Redirect to="/" />) 
               : (
                   <Login
-                    setUserToken={setUserToken}
+                    setAuth={setAuth}
                     {...props}
                   />
                 )

--- a/src/pages/cats/CatDetails.js
+++ b/src/pages/cats/CatDetails.js
@@ -201,23 +201,24 @@ export default function CatDetails (props) {
       {/* TODO: Change to only show if user 
       has proper permissions or created this cat */}
       {props.hasUser 
-        ? <>
-            <Button 
-              variant="contained" 
-              color="primary" 
-              onClick={() => props.history.push(`/cats/edit/${props.catId}`)}
-            >
-              Edit
-            </Button>
-            <Button 
-              variant="contained" 
-              color="primary" 
-              onClick={handleDelete}
-            >
-              Delete
-            </Button>
-          </>
-        : <></>
+        && parseInt(sessionStorage.getItem("user_id")) === parseInt(cat.creator_id) 
+          ? <>
+              <Button 
+                variant="contained" 
+                color="primary" 
+                onClick={() => props.history.push(`/cats/edit/${props.catId}`)}
+              >
+                Edit
+              </Button>
+              <Button 
+                variant="contained" 
+                color="primary" 
+                onClick={handleDelete}
+              >
+                Delete
+              </Button>
+            </>
+          : <></>
       }
     </>
   )

--- a/src/pages/users/Login.js
+++ b/src/pages/users/Login.js
@@ -28,7 +28,7 @@ const Login = props => {
     userManager.login(user)
       .then(resp => {
         if("token" in resp) {
-          props.setUserToken(resp)
+          props.setAuth(resp)
           props.history.push("/")
         }
         // If there is no token, 

--- a/src/pages/users/Register.js
+++ b/src/pages/users/Register.js
@@ -30,7 +30,7 @@ const Register = (props) => {
       .register(user)
       .then((resp) => {
         if ("token" in resp) {
-          props.setUserToken(resp);
+          props.setAuth(resp);
           props.history.push("/");
         }
       })


### PR DESCRIPTION
Features Added:
- only the authenticated user who created an animal is allowed to edit or delete it

Changes made:
- Renamed setUserToken to setAuth
- added user_id to session storage upon login/register
- added to the conditional rendering of edit/delete buttons a check that the authenticated user's id is the same as the userid that created the animal